### PR TITLE
Fix deprecated for SF > 2.6 and crash for SF > 3.0

### DIFF
--- a/DependencyInjection/MindfireExpiryFieldExtension.php
+++ b/DependencyInjection/MindfireExpiryFieldExtension.php
@@ -37,7 +37,11 @@ class MindfireExpiryFieldExtension extends Extension implements PrependExtension
      */
     public function prepend(ContainerBuilder $container)
     {
-        $config = array('form' => array('resources' => array('MindfireExpiryFieldBundle:Form:expiry.html.twig')));
+        if (Kernel::VERSION >= '2.6') {
+            $config = array('form_themes' => array('MindfireExpiryFieldBundle:Form:expiry.html.twig'));
+        } else {
+            $config = array('form' => array('resources' => array('MindfireExpiryFieldBundle:Form:expiry.html.twig')));
+        }
         try {
             $twigExtension = $container->getExtension('twig');
             $container->prependExtensionConfig($twigExtension->getAlias(), $config);

--- a/DependencyInjection/MindfireExpiryFieldExtension.php
+++ b/DependencyInjection/MindfireExpiryFieldExtension.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
Just another little fix for: The twig.form.resources configuration key is deprecated since version 2.6 and will be removed in 3.0. Use the twig.form_themes configuration key instead.
